### PR TITLE
ProfileApi reponse as object

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ $client = $builder->buildAuthenticated('%email%', '%password%');
 ### Profile
 Look for profile of an user called `panda_______`
 ```php
-$response = $client->getProfileApi()->get(PlatformType::PC, 'panda_______');
+$profiles = $client->getProfileApi()->get(PlatformType::PC, 'panda_______');
 ```
 | Parameters | Value               | Checks                                                    |
 |------------|---------------------|-----------------------------------------------------------|
@@ -50,26 +50,37 @@ $response = $client->getProfileApi()->get(PlatformType::PC, 'panda_______');
 | `$value`   | Value to search     | No real restrictions here                                 |
 | `$key`     | Key to search       | Possible values are: nameOnPlatform, idOnPlatform, userId |
 
-`$response` will contains:
-```
-array(1) {
-  'profiles' =>
-  array(1) {
-    [0] =>
-    array(5) {
-      'profileId' =>
-      string(36) "575b8c76-a33a-4c19-9618-d14b9343d527"
-      'userId' =>
-      string(36) "575b8c76-a33a-4c19-9618-d14b9343d527"
-      'platformType' =>
-      string(5) "uplay"
-      'idOnPlatform' =>
-      string(36) "575B8C76-A33A-4C19-9618-D14B9343D527"
-      'nameOnPlatform' =>
-      string(12) "panda_______"
-    }
-  }
+`$profiles` will contains an array of `Profile` model:
+```php
+class Profile
+{
+    /**
+     * @var \Ramsey\Uuid\Uuid
+     */
+    public $profileId;
+
+    /**
+     * @var \Ramsey\Uuid\Uuid
+     */
+    public $userId;
+
+    /**
+     * @var string
+     * @see \R6API\Client\Api\Type\PlatformType
+     */
+    public $platformType;
+
+    /**
+     * @var \Ramsey\Uuid\Uuid
+     */
+    public $idOnPlatform;
+
+    /**
+     * @var string
+     */
+    public $nameOnPlatform;
 }
+
 ```
 
 ### Progression

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     },
     "require": {
         "php": ">=7.1",
+        "ext-ctype": "*",
         "psr/http-message": "^1.0",
         "php-http/httplug": "^1.0",
         "php-http/message": "^1.0",
@@ -22,12 +23,18 @@
         "php-http/message-factory": "^v1.0",
         "php-http/client-implementation": "^1.0",
         "psr/cache": "^1.0",
-        "greg0ire/enum": "^4.0"
+        "greg0ire/enum": "^4.0",
+        "symfony/serializer": "^4.1",
+        "ramsey/uuid": "^3.8",
+        "symfony/property-access": "^4.1"
     },
     "require-dev": {
         "php-http/guzzle6-adapter": "^1.1",
         "phpunit/phpunit": "^7.3",
         "cache/predis-adapter": "^1.0"
+    },
+    "replace": {
+        "symfony/polyfill-ctype": "*"
     },
     "suggest": {
         "php-http/curl-client": "In order to use cURL as the HTTP client",

--- a/src/Api/AbstractApi.php
+++ b/src/Api/AbstractApi.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace R6API\Client\Api;
 
 use R6API\Client\Http\ResourceClientInterface;
+use Symfony\Component\Serializer\SerializerInterface;
 
 /**
  * Abstract API implementation.
@@ -15,11 +16,12 @@ abstract class AbstractApi
     /** @var ResourceClientInterface */
     protected $resourceClient;
 
-    /**
-     * @param ResourceClientInterface $resourceClient
-     */
-    public function __construct(ResourceClientInterface $resourceClient)
+    /** @var SerializerInterface */
+    protected $serializer;
+
+    public function __construct(ResourceClientInterface $resourceClient, SerializerInterface $serializer)
     {
         $this->resourceClient = $resourceClient;
+        $this->serializer = $serializer;
     }
 }

--- a/src/Api/ProfileApi.php
+++ b/src/Api/ProfileApi.php
@@ -5,6 +5,7 @@ namespace R6API\Client\Api;
 
 use R6API\Client\Api\Type\PlatformType;
 use R6API\Client\Exception\ApiException;
+use R6API\Client\Model\ProfileResponse;
 
 /**
  * API implementation to manage the profiles.
@@ -39,6 +40,12 @@ class ProfileApi extends AbstractApi implements ProfileApiInterface
             'platformType' => constant(PlatformType::class.'::_PROFILES_'.$platform),
             $key => $value
         ];
-        return $this->resourceClient->getResource(self::URL, $parameters);
+
+        $data = $this->resourceClient->getResource(self::URL, $parameters);
+        return $this->serializer->deserialize(
+            $data,
+            ProfileResponse::class,
+            'json'
+        );
     }
 }

--- a/src/Denormalizer/ProfileDenormalizer.php
+++ b/src/Denormalizer/ProfileDenormalizer.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace R6API\Client\Denormalizer;
+
+use R6API\Client\Api\Type\PlatformType;
+use R6API\Client\Model\Profile;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+class ProfileDenormalizer implements DenormalizerInterface
+{
+    public function denormalize($data, $class, $format = null, array $context = [])
+    {
+        $profile = new Profile();
+
+        $profile->profileId = Uuid::fromString($data['profileId']);
+        $profile->userId = Uuid::fromString($data['userId']);
+        $profile->idOnPlatform = Uuid::fromString($data['idOnPlatform']);
+
+        $platformType = str_replace('_PROFILES_', '', PlatformType::getKeysFromValue($data['platformType']));
+        $profile->platformType = $platformType;
+
+        $profile->nameOnPlatform = $data['nameOnPlatform'];
+
+        return $profile;
+    }
+
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        $supports = false;
+        if (Profile::class === $type) {
+            $supports = true;
+        }
+
+        return $supports;
+    }
+}

--- a/src/Denormalizer/ProfileResponseDenormalizer.php
+++ b/src/Denormalizer/ProfileResponseDenormalizer.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace R6API\Client\Denormalizer;
+
+use R6API\Client\Model\Profile;
+use R6API\Client\Model\ProfileResponse;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+class ProfileResponseDenormalizer implements DenormalizerInterface, DenormalizerAwareInterface
+{
+    /** @var DenormalizerInterface */
+    private $denormalizer;
+
+    public function denormalize($data, $class, $format = null, array $context = [])
+    {
+        $profiles = [];
+
+        foreach ($data['profiles'] as $profile) {
+            $profiles[] = $this->denormalizer->denormalize($profile, Profile::class);
+        }
+
+        return $profiles;
+    }
+
+    public function supportsDenormalization($data, $type, $format = null): bool
+    {
+        $supports = false;
+        if (ProfileResponse::class === $type) {
+            $supports = true;
+        }
+
+        return $supports;
+    }
+
+    public function setDenormalizer(DenormalizerInterface $denormalizer)
+    {
+        $this->denormalizer = $denormalizer;
+    }
+}

--- a/src/Http/ResourceClient.php
+++ b/src/Http/ResourceClient.php
@@ -38,6 +38,6 @@ class ResourceClient implements ResourceClientInterface
         $uri = $this->uriGenerator->generate($uri, $uriParameters, $queryParameters);
         $response = $this->httpClient->sendRequest('GET', $uri);
 
-        return json_decode($response->getBody()->getContents(), true);
+        return $response->getBody()->getContents();
     }
 }

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -19,7 +19,8 @@ class Profile
     public $userId;
 
     /**
-     * @var PlatformType
+     * @var string
+     * @see PlatformType
      */
     public $platformType;
 

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace R6API\Client\Model;
+
+use Ramsey\Uuid\Uuid;
+use R6API\Client\Api\Type\PlatformType;
+
+class Profile
+{
+    /**
+     * @var Uuid
+     */
+    public $profileId;
+
+    /**
+     * @var Uuid
+     */
+    public $userId;
+
+    /**
+     * @var PlatformType
+     */
+    public $platformType;
+
+    /**
+     * @var Uuid;
+     */
+    public $idOnPlatform;
+
+    /**
+     * @var string
+     */
+    public $nameOnPlatform;
+}

--- a/tests/Api/ProfileApiTest.php
+++ b/tests/Api/ProfileApiTest.php
@@ -3,6 +3,8 @@
 namespace R6API\Client\tests\Api;
 
 use R6API\Client\Api\Type\PlatformType;
+use R6API\Client\Model\Profile;
+use Ramsey\Uuid\Uuid;
 
 /**
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>
@@ -11,15 +13,20 @@ class ProfileApiTest extends ApiTestCase
 {
     public function testSimpleSearch()
     {
-        $response = $this->client->getProfileApi()->get(PlatformType::PC, 'panda_______');
+        $profiles = $this->client->getProfileApi()->get(PlatformType::PC, 'panda_______');
 
-        $this->assertArrayHasKey('profiles', $response);
+        $this->assertTrue(is_array($profiles));
 
-        $this->assertArrayHasKey('profileId', $response['profiles'][0]);
-        $this->assertArrayHasKey('userId', $response['profiles'][0]);
-        $this->assertArrayHasKey('platformType', $response['profiles'][0]);
-        $this->assertArrayHasKey('idOnPlatform', $response['profiles'][0]);
-        $this->assertArrayHasKey('nameOnPlatform', $response['profiles'][0]);
+        /** @var Profile $profile */
+        $profile = $profiles[0];
+
+        $this->assertTrue($profile instanceof Profile);
+
+        $this->assertTrue($profile->profileId instanceof Uuid);
+        $this->assertTrue($profile->userId instanceof Uuid);
+        $this->assertTrue($profile->idOnPlatform instanceof Uuid);
+        $this->assertEquals(PlatformType::PC, $profile->platformType);
+        $this->assertEquals('panda_______', $profile->nameOnPlatform);
     }
 
     /**


### PR DESCRIPTION
Issue: #8 & #9
# Done
- Adding symfony/serializer to convert json to objects
- First two denormalizer (classes to convert json to object)
- AbstractApi now include $serializer shared variable
- ResourceClient now returns json string instead of array (⚠️ will probably break other endpoints)

# Todo
- [x] Tests
- [x] Docs